### PR TITLE
Disable download button and picture-in-picture button on video player

### DIFF
--- a/Pages/Detail/DetailVideo/DetailVideoPlayer/DetailVideoPlayer.razor
+++ b/Pages/Detail/DetailVideo/DetailVideoPlayer/DetailVideoPlayer.razor
@@ -31,7 +31,9 @@
                     {
                         <BlazoredVideo @ref="videoRef"
                             style="width: inherit;
-                                box-shadow: 1px 1px 16px rgba(30, 32, 34, 0.6);" 
+                                box-shadow: 1px 1px 16px rgba(30, 32, 34, 0.6);"
+                            disablePictureInPicture
+                            controlsList="nodownload"
                             controls="controls">
                             <source src="@Video.VideoUrl" />
                         </BlazoredVideo>

--- a/Pages/StandalonePlayer/StandalonePlayer.razor
+++ b/Pages/StandalonePlayer/StandalonePlayer.razor
@@ -52,7 +52,9 @@ else
                             {
                                 <BlazoredVideo @ref="videoRef"
                                     style="width: inherit;
-                                        box-shadow: 1px 1px 16px rgba(30, 32, 34, 0.6);" 
+                                        box-shadow: 1px 1px 16px rgba(30, 32, 34, 0.6);"
+                                    disablePictureInPicture
+                                    controlsList="nodownload" 
                                     controls="controls">
                                     <source src="@videoData.VideoUrl" />
                                 </BlazoredVideo>


### PR DESCRIPTION
NOTE: Picture-In-Picture cannot be disabled on some browsers (for example, Firefox)